### PR TITLE
[Update] fetch Description from latest html of GitHub trending

### DIFF
--- a/trending.py
+++ b/trending.py
@@ -151,7 +151,7 @@ class Repositories(Trends):
             repo_organization, repo_name = item.find("h1", class_="h3 lh-condensed").text.strip(' \t\n\r').split("/")
             repository = "{}/{}".format(repo_organization.strip(), repo_name.strip())
 
-            repo_desc_info = item.find("p", class_="col-9 color-text-secondary my-1 pr-4")
+            repo_desc_info = item.find("p", class_="col-9 color-fg-muted my-1 pr-4")
             language_info = item.find("span", itemprop="programmingLanguage")
             stars_info = item.find("a", class_="Link--muted d-inline-block mr-3")
 


### PR DESCRIPTION
Fixed a bug that "Description" could not be fetched because the DOM structure of the latest GitHub Trending HTML had changed.  
  
・Description
### After
```html
<p class="col-9 color-fg-muted my-1 pr-4">
```
### Before
```html
<p class="col-9 color-text-secondary my-1 pr-4">
```